### PR TITLE
Feat: Logic for mean operation

### DIFF
--- a/examples/mean.rs
+++ b/examples/mean.rs
@@ -1,0 +1,32 @@
+use numru::arr;
+use std::f64::consts::{E, PI, TAU};
+
+fn main() {
+    let a = arr![42, -17, 256, 3, 99, -8];
+    let a_mean = a.mean().compute();
+    println!("a.mean() = {:?}", a_mean);
+    // Note: For 1D arrays, axis doesn't make sense, but this is for demonstration
+    let a_mean_axis = a.mean().axis(0).compute();
+    println!("a.mean().axis(0) = {:?}", a_mean_axis);
+
+    let b = arr![[TAU, -PI, 1.61], [E, 0.98, -7.42], [4.67, -0.45, 8.88]];
+    let b_mean = b.mean().compute();
+    println!("b.mean() = {:?}", b_mean);
+    let b_mean_axis_0 = b.mean().axis(0).compute();
+    println!("b.mean().axis(0) = {:?}", b_mean_axis_0);
+    let b_mean_axis_1 = b.mean().axis(1).compute();
+    println!("b.mean().axis(1) = {:?}", b_mean_axis_1);
+
+    let c = arr![
+        [[101, 202, 303], [404, 505, 606]],
+        [[-707, -808, -909], [111, 222, 333]]
+    ];
+    let c_mean = c.mean().compute();
+    println!("c.mean() = {:?}", c_mean);
+    let c_mean_axis_0 = c.mean().axis(0).compute();
+    println!("c.mean().axis(0) = {:?}", c_mean_axis_0);
+    let c_mean_axis_1 = c.mean().axis(1).compute();
+    println!("c.mean().axis(1) = {:?}", c_mean_axis_1);
+    let c_mean_axis_2 = c.mean().axis(2).compute();
+    println!("c.mean().axis(2) = {:?}", c_mean_axis_2);
+} 

--- a/src/array.rs
+++ b/src/array.rs
@@ -405,6 +405,17 @@ mod tests {
 
     use crate::{Dimension, Ix, Shape};
 
+    fn round_to_3dp(value: f64) -> f64 {
+        (value * 1000.0).round() / 1000.0
+    }
+
+    fn assert_vec_approx_eq(actual: Vec<f64>, expected: Vec<f64>) {
+        assert_eq!(actual.len(), expected.len(), "Vectors have different lengths");
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert_eq!(round_to_3dp(*a), round_to_3dp(*e), "Values differ: {} != {}", a, e);
+        }
+    }
+
     #[test]
     fn array_creation_i64_1d() {
         let arr = arr![1, 2, 3, 4];
@@ -932,5 +943,73 @@ mod tests {
         assert_eq!(arr.shape().raw_dim().ndim(), 3);
         assert_eq!(arr.dtype(), "float64");
         assert_eq!(arr.data(), &vec![1.0f64; 12]);
+    }
+
+    #[test]
+    fn mean_i64_1d() {
+        let arr = arr![42, -17, 256, 3, 99, -8];
+        let expected_mean = vec![62.5];
+        assert_vec_approx_eq(arr.mean().compute(), expected_mean);
+    }
+
+    #[test]
+    fn mean_f64_1d() {
+        let arr = arr![PI, 2.71, -1.0, 42.0, 0.98];
+        let expected_mean = vec![9.566];
+        assert_vec_approx_eq(arr.mean().compute(), expected_mean);
+    }
+
+    #[test]
+    fn mean_i64_2d() {
+        let arr = arr![[1, 5, 3], [4, 2, 6], [0, 9, 8]];
+        let expected_mean = vec![4.222];
+        let expected_mean_axis_0 = vec![1.667, 5.333, 5.667];
+        let expected_mean_axis_1 = vec![3.0, 4.0, 5.667];
+        assert_vec_approx_eq(arr.mean().compute(), expected_mean);
+        assert_vec_approx_eq(arr.mean().axis(0).compute(), expected_mean_axis_0);
+        assert_vec_approx_eq(arr.mean().axis(1).compute(), expected_mean_axis_1);
+    }
+
+    #[test]
+    fn mean_f64_2d() {
+        let arr = arr![[PI, -2.71, 1.61], [E, 0.98, -7.42], [4.67, -0.45, 8.88]];
+        let expected_mean = vec![1.269];
+        let expected_mean_axis_0 = vec![3.51, -0.727, 1.023];
+        let expected_mean_axis_1 = vec![0.681, -1.241, 4.367];
+        assert_vec_approx_eq(arr.mean().compute(), expected_mean);
+        assert_vec_approx_eq(arr.mean().axis(0).compute(), expected_mean_axis_0);
+        assert_vec_approx_eq(arr.mean().axis(1).compute(), expected_mean_axis_1);
+    }
+
+    #[test]
+    fn mean_i64_3d() {
+        let arr = arr![
+            [[101, 202, 303], [404, 505, 606]],
+            [[-707, -808, -909], [111, 222, 333]]
+        ];
+        let expected_mean = vec![30.25];
+        let expected_mean_axis_0 = vec![-303.0, -303.0, -303.0, 257.5, 363.5, 469.5];
+        let expected_mean_axis_1 = vec![252.5, 353.5, 454.5, -298.0, -293.0, -288.0];
+        let expected_mean_axis_2 = vec![202.0, 505.0, -808.0, 222.0];
+        assert_vec_approx_eq(arr.mean().compute(), expected_mean);
+        assert_vec_approx_eq(arr.mean().axis(0).compute(), expected_mean_axis_0);
+        assert_vec_approx_eq(arr.mean().axis(1).compute(), expected_mean_axis_1);
+        assert_vec_approx_eq(arr.mean().axis(2).compute(), expected_mean_axis_2);
+    }
+
+    #[test]
+    fn mean_f64_3d() {
+        let arr = arr![
+            [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]],
+            [[7.7, 8.8, 9.9], [10.0, 11.1, 12.2]]
+        ];
+        let expected_mean = vec![6.9];
+        let expected_mean_axis_0 = vec![4.4, 5.5, 6.6, 7.2, 8.3, 9.4];
+        let expected_mean_axis_1 = vec![2.75, 3.85, 4.95, 8.85, 9.95, 11.05];
+        let expected_mean_axis_2 = vec![2.2, 5.5, 8.8, 11.1];
+        assert_vec_approx_eq(arr.mean().compute(), expected_mean);
+        assert_vec_approx_eq(arr.mean().axis(0).compute(), expected_mean_axis_0);
+        assert_vec_approx_eq(arr.mean().axis(1).compute(), expected_mean_axis_1);
+        assert_vec_approx_eq(arr.mean().axis(2).compute(), expected_mean_axis_2);
     }
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -68,6 +68,38 @@ where
     }
 }
 
+/// A builder for computing the mean values of an array.
+pub struct MeanBuilder<'a, T, D> 
+where
+    T: PartialOrd + Copy + Into<f64>,
+    D: Dimension
+{
+    array: &'a Array<T,D>,
+    axis: Option<usize>    
+}
+
+impl<'a, T, D> MeanBuilder<'a, T, D> 
+where
+    T: PartialOrd + Copy + Into<f64>,
+    D: Dimension
+{
+    /// Creates a new `MeanBuilder` with the given array.
+    pub fn new(array: &'a Array<T, D>) -> Self {
+        Self { array, axis: None }
+    }
+
+    /// Sets the axis along which to compute the minimum.
+    pub fn axis(mut self, axis: usize) -> Self {
+        self.axis = Some(axis);
+        self
+    }
+
+    /// Computes the mean values based on the current configuration.
+    pub fn compute(self) -> Vec<f64> {
+        self.array.mean_compute(self.axis).unwrap()
+    }
+}
+
 impl<T: PartialOrd + Copy, D: Dimension> Array<T, D> {
     /// Starts building a computation for the maximum values of this array.
     pub fn max(&self) -> MaxBuilder<T, D> {
@@ -78,6 +110,15 @@ impl<T: PartialOrd + Copy, D: Dimension> Array<T, D> {
     pub fn min(&self) -> MinBuilder<T, D> {
         MinBuilder::new(self)
     }
+
+    /// Starts building a computation for the mean values of this array.
+    pub fn mean(&self) -> MeanBuilder<T, D> 
+    where 
+        T: Into<f64>
+    {
+        MeanBuilder::new(self)
+    }
+
 }
 
 impl<T, D> Debug for MaxBuilder<'_, T, D>
@@ -109,6 +150,28 @@ where
     /// Formats the `MinBuilder` for debugging.
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("MinBuilder")
+            .field(
+                "array",
+                &format_args!(
+                    "Array<{}, {}>",
+                    std::any::type_name::<T>(),
+                    std::any::type_name::<D>()
+                ),
+            )
+            .field("axis", &self.axis)
+            .finish()
+    }
+}
+
+
+impl<T, D> Debug for MeanBuilder<'_, T, D>
+where
+    T: PartialOrd + Copy + Into<f64>,
+    D: Dimension,
+{
+    /// Formats the `MeanBuilder` for debugging.
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MeanBuilder")
             .field(
                 "array",
                 &format_args!(


### PR DESCRIPTION
PR for the Issue #3  [ feature implementation : Implement a.mean() similar to a.max() and a.min() ]

Added a trait bound T: Into<f64> to mean_compute method to ensure numeric types can be converted to f64 for mean calculation. The MeanBuilder takes care of this trait bound as well.